### PR TITLE
Fixed "thrown type FileNotFoundException has already been caught"

### DIFF
--- a/src/android/Thumbnails.java
+++ b/src/android/Thumbnails.java
@@ -123,9 +123,6 @@ public class Thumbnails {
             bitmap.compress(guessImageType(targetPath), 90, os);
         } catch (FileNotFoundException ex) {
             throw new TargetPathNotFoundException(ex);
-        } catch (IOException ex) {
-            Log.e("Thumbnails.saveBitmapToFile()", "Error opening file stream:" + targetPath);
-            ex.printStackTrace();
         } finally {
             if (os != null) {
                 try {


### PR DESCRIPTION
Removes the warning below:
com/cordova/plugin/thumbnail/Thumbnails.java:126: warning: unreachable catch clause
} catch (IOException ex) {
^
thrown type FileNotFoundException has already been caught