### PR TITLE
force thumbnail generation

### DIFF
--- a/src/ios/Thumbnail.m
+++ b/src/ios/Thumbnail.m
@@ -94,7 +94,8 @@
     NSDictionary *imageOptions = @{
                                    (NSString const *)kCGImageSourceCreateThumbnailFromImageIfAbsent : (NSNumber const *)kCFBooleanTrue,
                                    (NSString const *)kCGImageSourceThumbnailMaxPixelSize            : @(maxPixelSize),
-                                   (NSString const *)kCGImageSourceCreateThumbnailWithTransform     : (NSNumber const *)kCFBooleanTrue
+                                   (NSString const *)kCGImageSourceCreateThumbnailWithTransform     : (NSNumber const *)kCFBooleanTrue,
+                                   (NSString const *)kCGImageSourceCreateThumbnailFromImageAlways   : (NSNumber const *)kCFBooleanTrue
                                    };
     CGImageRef thumbnail = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, (__bridge CFDictionaryRef)imageOptions);
     CFRelease(imageSource);


### PR DESCRIPTION
The property with key kCGImageSourceCreateThumbnailFromImageAlways with a value of true means that any thumbnail image embedded in the image file is ignored and the image generated is from the full size image. If you don’t do this and the image file contains a thumbnail image then the max size you specify is ignored and you get the embedded thumbnail image, this is rarely what you want.